### PR TITLE
Add tables summarizing arbitrage examples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,6 @@ jobs:
     container:
       image: ghcr.io/mmore500/teximage:sha-77b8179
       options: --user root
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,11 @@ jobs:
         run: |
           trap 'cat *.log || true >> "$GITHUB_OUTPUT"' EXIT
           make
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-pdf
+          path: ${{ github.event.repository.name }}-draft.pdf
 
   latex:
     name: Latex Build and Deploy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,6 @@ jobs:
     container:
       image: ghcr.io/mmore500/teximage:sha-77b8179
       options: --user root
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,32 @@ on:
       - tex
 
 jobs:
+  latex-test:
+    name: Latex Test
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/mmore500/teximage:sha-77b8179
+      options: --user root
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Build LaTeX document
+        run: |
+          trap 'cat *.log || true >> "$GITHUB_OUTPUT"' EXIT
+          make
 
   latex:
     name: Latex Build and Deploy
     runs-on: ubuntu-22.04
+    if: github.ref == 'refs/heads/master'
     container:
       image: ghcr.io/mmore500/teximage:sha-77b8179
       options: --user root

--- a/lib/dependencies.tex
+++ b/lib/dependencies.tex
@@ -5,6 +5,7 @@
 \usepackage{authblk}
 \usepackage{bibunits}
 \usepackage{booktabs}
+\usepackage{multirow}
 \usepackage{caption}
 \usepackage{csvsimple}
 \usepackage{etoolbox}

--- a/tab/arbitrage-examples.tex
+++ b/tab/arbitrage-examples.tex
@@ -1,0 +1,25 @@
+\begin{table*}
+\centering
+\caption{Representative examples of evolutionary computation work that leverages theory from biology.}
+\label{tab:arbitrage-examples}
+\begin{tabular}{@{}p{3.2cm}p{5.8cm}p{6cm}@{}}
+\toprule
+\textbf{Theme} & \textbf{Topic} & \textbf{Reference} \\
+\midrule
+\multirow{2}{*}{Genotype-Phenotype Maps} & Quantifying Deception: A Case Study in the Evolution of Antimicrobial Resistance & \citep{eppstein2016quantifying} \\
+ & The arrival of the frequent: how bias in genotype-phenotype maps can steer populations to local optima & \citep{schaper2014arrival} \\
+\midrule
+\multirow{2}{*}{Ecology} & Reachability Analysis for Lexicase Selection via Community Assembly Graphs & \citep{dolson2024reachability} \\
+ & Ecological theory provides insights about evolutionary computation & \citep{dolson2018ecological} \\
+\midrule
+\multirow{3}{*}{Phylogeny Analysis} & What can phylogenetic metrics tell us about useful diversity in evolutionary algorithms? & \citep{hernandez2022can} \\
+ & Untangling phylogenetic diversity's role in evolutionary computation using a suite of diagnostic fitness landscapes & \citep{shahbandegan2022untangling} \\
+ & Interactions between learning and evolution & \citep{ackley1991interactions} \\
+\midrule
+\multirow{2}{*}{Sampling and Tracking Partial Observability} & Methods for Rich Phylogenetic Inference Over Distributed Sexual Populations & \citep{moreno2024methods} \\
+ & A Guide to Tracking Phylogenies in Parallel and Distributed Agent-based Evolution Models & \citep{moreno2024guide} \\
+\midrule
+Interoperation with Bioinformatics Infrastructure & Data Standards for Artificial Life Software & \citep{lalejini2019data} \\
+\bottomrule
+\end{tabular}
+\end{table*}

--- a/tab/arbitrage-examples.tex
+++ b/tab/arbitrage-examples.tex
@@ -2,24 +2,26 @@
 \centering
 \caption{Representative examples of evolutionary computation work that leverages theory from biology.}
 \label{tab:arbitrage-examples}
+\renewcommand{\arraystretch}{1.6} % vertical padding between table rows
 \begin{tabular}{@{}p{3.2cm}p{5.8cm}p{6cm}@{}}
 \toprule
 \textbf{Theme} & \textbf{Topic} & \textbf{Reference} \\
 \midrule
-\multirow{2}{*}{Genotype-Phenotype Maps} & Quantifying Deception: A Case Study in the Evolution of Antimicrobial Resistance & \citep{eppstein2016quantifying} \\
+\multirow{2}{\linewidth}{Genotype-Phenotype Maps} & Quantifying Deception: A Case Study in the Evolution of Antimicrobial Resistance & \citep{eppstein2016quantifying} \\
  & The arrival of the frequent: how bias in genotype-phenotype maps can steer populations to local optima & \citep{schaper2014arrival} \\
 \midrule
-\multirow{2}{*}{Ecology} & Reachability Analysis for Lexicase Selection via Community Assembly Graphs & \citep{dolson2024reachability} \\
+\multirow{2}{\linewidth}{Ecology} & Reachability Analysis for Lexicase Selection via Community Assembly Graphs & \citep{dolson2024reachability} \\
  & Ecological theory provides insights about evolutionary computation & \citep{dolson2018ecological} \\
 \midrule
-\multirow{3}{*}{Phylogeny Analysis} & What can phylogenetic metrics tell us about useful diversity in evolutionary algorithms? & \citep{hernandez2022can} \\
+\multirow{3}{\linewidth}{Phylogeny Analysis} & What can phylogenetic metrics tell us about useful diversity in evolutionary algorithms? & \citep{hernandez2022can} \\
  & Untangling phylogenetic diversity's role in evolutionary computation using a suite of diagnostic fitness landscapes & \citep{shahbandegan2022untangling} \\
  & Interactions between learning and evolution & \citep{ackley1991interactions} \\
 \midrule
-\multirow{2}{*}{Sampling and Tracking Partial Observability} & Methods for Rich Phylogenetic Inference Over Distributed Sexual Populations & \citep{moreno2024methods} \\
+\multirow{2}{\linewidth}{Sampling and Tracking Partial Observability} & Methods for Rich Phylogenetic Inference Over Distributed Sexual Populations & \citep{moreno2024methods} \\
  & A Guide to Tracking Phylogenies in Parallel and Distributed Agent-based Evolution Models & \citep{moreno2024guide} \\
 \midrule
-Interoperation with Bioinformatics Infrastructure & Data Standards for Artificial Life Software & \citep{lalejini2019data} \\
+\multirow{2}{\linewidth}{Interoperation with Bioinformatics Infrastructure} & Data Standards for Artificial Life Software & \citep{lalejini2019data} \\
+& alifedata-phyloinformatics-convert & \citep{moreno2024apc} \\
 \bottomrule
 \end{tabular}
 \end{table*}

--- a/tab/arbitrage-opportunities.tex
+++ b/tab/arbitrage-opportunities.tex
@@ -2,20 +2,21 @@
 \centering
 \caption{Selected evolutionary biology literature that may inform future theory arbitrage in evolutionary computation.}
 \label{tab:arbitrage-opportunities}
+\renewcommand{\arraystretch}{1.6} % vertical padding between table rows
 \begin{tabular}{@{}p{3.2cm}p{5.8cm}p{6cm}@{}}
 \toprule
 \textbf{Theme} & \textbf{Topic} & \textbf{Reference} \\
 \midrule
-Genotype-Phenotype Maps & Evolution in the light of fitness landscape theory & \citep{fragata2019evolution} \\
+\multirow{2}{\linewidth}{Genotype-Phenotype Maps} & Evolution in the light of fitness landscape theory & \citep{fragata2019evolution} \\
 \midrule
-\multirow{2}{*}{Ecology} & The priority of prediction in ecological understanding & \citep{houlahan2016priority} \\
+\multirow{2}{\linewidth}{Ecology} & The priority of prediction in ecological understanding & \citep{houlahan2016priority} \\
  & Addressing context dependence in ecology & \citep{catford2022addressing} \\
 \midrule
-Phylogeny Analysis & Phylogenomics and the reconstruction of the tree of life & \citep{delsuc2005phylogenomics,abaza2020what} \\
+\multirow{1}{\linewidth}{Phylogeny Analysis} & Phylogenomics and the reconstruction of the tree of life & \citep{delsuc2005phylogenomics,abaza2020what} \\
 \midrule
-Sampling and Tracking Partial Observability & Handbook of capture-recapture analysis & \citep{amstrup2010handbook,burnham1979robust} \\
+\multirow{1}{\linewidth}{Sampling-based Estimation and Partial Observability} & Handbook of capture-recapture analysis & \citep{amstrup2010handbook,burnham1979robust} \\
 \midrule
-Interoperation with Bioinformatics Infrastructure & Tools for exploring massive phylogenies & \citep{sanderson2022taxonium,moshiri2025compacttree,moshiri2020treeswift} \\
+\multirow{1}{\linewidth}{Interoperation with Bioinformatics Infrastructure} & Tools for exploring massive phylogenies & \citep{sanderson2022taxonium,moshiri2025compacttree,moshiri2020treeswift} \\
 \bottomrule
 \end{tabular}
 \end{table*}

--- a/tab/arbitrage-opportunities.tex
+++ b/tab/arbitrage-opportunities.tex
@@ -1,0 +1,21 @@
+\begin{table*}
+\centering
+\caption{Selected evolutionary biology literature that may inform future theory arbitrage in evolutionary computation.}
+\label{tab:arbitrage-opportunities}
+\begin{tabular}{@{}p{3.2cm}p{5.8cm}p{6cm}@{}}
+\toprule
+\textbf{Theme} & \textbf{Topic} & \textbf{Reference} \\
+\midrule
+Genotype-Phenotype Maps & Evolution in the light of fitness landscape theory & \citep{fragata2019evolution} \\
+\midrule
+\multirow{2}{*}{Ecology} & The priority of prediction in ecological understanding & \citep{houlahan2016priority} \\
+ & Addressing context dependence in ecology & \citep{catford2022addressing} \\
+\midrule
+Phylogeny Analysis & Phylogenomics and the reconstruction of the tree of life & \citep{delsuc2005phylogenomics,abaza2020what} \\
+\midrule
+Sampling and Tracking Partial Observability & Handbook of capture-recapture analysis & \citep{amstrup2010handbook,burnham1979robust} \\
+\midrule
+Interoperation with Bioinformatics Infrastructure & Tools for exploring massive phylogenies & \citep{sanderson2022taxonium,moshiri2025compacttree,moshiri2020treeswift} \\
+\bottomrule
+\end{tabular}
+\end{table*}

--- a/tab/bioinspiration.tex
+++ b/tab/bioinspiration.tex
@@ -2,6 +2,7 @@
 \centering
 \caption{Conceptual analogies between evolutionary computation (EC) mechanisms and biological processes.}
 \label{tab:bioinspiration}
+\renewcommand{\arraystretch}{1.6} % vertical padding between table rows
 \begin{tabular}{@{}p{4.2cm}p{4.2cm}p{6.5cm}@{}}
 \toprule
 \textbf{EC Mechanism} & \textbf{Biological Analogy} & \textbf{References} \\

--- a/text/body/introduction.tex
+++ b/text/body/introduction.tex
@@ -81,6 +81,9 @@ We also highlight opportunities where methods and tools can overlap with bioinfo
 \end{itemize}
 Additional opportunities for theory arbitrage remain entirely unexplored, however --- which we also outline (Section \ref{sec:opportunities}).
 
+Table~\ref{tab:arbitrage-examples} overviews representative EC work drawing on biological theory.
+\input{tab/arbitrage-examples.tex}
+
 % ELD: Would be good to include some examples here that aren't things we/friends did.
 
 Despite its promise, borrowing from biology should not be taken as a silver bullet.

--- a/text/body/opportunities.tex
+++ b/text/body/opportunities.tex
@@ -7,3 +7,6 @@ future work:
   \item detecting speciation through population genetics methods \citep{sukumaran2021incorporating}
   \item Inferring Fitness landscapes and selection on phenotypic states from single-cell genealogical data \citep{nozoe2017inferring}
 \end{itemize}
+
+Table~\ref{tab:arbitrage-opportunities} lists selected directions from evolutionary biology that could enrich EC theory.
+\input{tab/arbitrage-opportunities.tex}


### PR DESCRIPTION
## Summary
- add new table of EC examples using biological theory
- add new table of biological opportunities for future theory arbitrage
- include tables in introduction and opportunities sections
- enable multirow support

## Testing
- `make test` *(fails: pdflatex command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc3a9f448322b560d15cb263973e