### PR TITLE
Add nonacm option to acmart documentclass and update abstract

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,13 @@
+% TODO: remove the `nonacm` option once ACM submission metadata is finalized.
+% `nonacm` currently suppresses three blocks of placeholder boilerplate that
+% acmart would otherwise generate from the (not-yet-filled-in) rights/journal
+% info: the "ACM Reference Format:" block, the copyright/permission notice
+% (including the "ACM XXXX-XXXX/..." ISSN and DOI lines), and the journal page
+% footer ("..., Vol. 1, No. 1, Article . Publication date: ...").
 \ifdefined\mydraft
-\documentclass[acmsmall, screen=true, review=true, natbib=true]{acmart}
+\documentclass[acmsmall, nonacm, screen=true, review=true, natbib=true]{acmart}
 \else
-\documentclass[acmsmall, screen=true, review=false, natbib=true]{acmart}
+\documentclass[acmsmall, nonacm, screen=true, review=false, natbib=true]{acmart}
 \fi
 
 \input{lib/dependencies.tex}

--- a/text/abstract.tex
+++ b/text/abstract.tex
@@ -1,3 +1,3 @@
 \begin{abstract}
-TODO
+% TODO
 \end{abstract}


### PR DESCRIPTION
## Summary
This PR updates the LaTeX document configuration to suppress ACM-specific boilerplate content during the manuscript preparation phase, and marks the abstract as a placeholder for future completion.

## Key Changes
- Added `nonacm` option to both draft and final `\documentclass` declarations in `main.tex`
  - This suppresses three blocks of ACM placeholder boilerplate: the "ACM Reference Format:" block, copyright/permission notice with ISSN/DOI lines, and journal page footer
  - Includes detailed comment explaining the purpose and scope of the `nonacm` option
- Updated abstract placeholder in `text/abstract.tex` from `TODO` to `% TODO` to properly format it as a LaTeX comment

## Implementation Details
The `nonacm` option is intended to be temporary and should be removed once ACM submission metadata (rights and journal information) is finalized. This allows for cleaner document rendering during the review and preparation phases without the incomplete ACM metadata blocks.

https://claude.ai/code/session_0196vJ6WYM1tHXbKwjTwKGpm