### PR TITLE
Replace section references with TODO placeholders

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -41,7 +41,7 @@
 
   \input{text/supplement.tex}
 
-  % \input{text/references.tex}
+  \input{text/references.tex}
 
 \end{bibunit}
 

--- a/text/body.tex
+++ b/text/body.tex
@@ -3,6 +3,8 @@
 % \putbib[bibl]
 % \end{bibunit}
 
+\phantomsection\label{sec:TODO}
+
 \section{Fundamental Concepts}
 \label{sec:fundamental-concepts}
 

--- a/text/body.tex
+++ b/text/body.tex
@@ -3,8 +3,6 @@
 % \putbib[bibl]
 % \end{bibunit}
 
-\phantomsection\label{sec:TODO}
-
 \section{Fundamental Concepts}
 \label{sec:fundamental-concepts}
 

--- a/text/body/conclusion.tex
+++ b/text/body/conclusion.tex
@@ -11,7 +11,7 @@ In this review, we have highlighted notable examples where reaching into the bio
 Such research, much of it very recent, reflects only first steps.
 Important extensions remain to be fleshed out and connected to \textit{bona fide} real-world use cases.
 Further, reviewed work touches only a small fraction of promising directions for arbitrage from biology to evolutionary computation.
-In Section \ref{sec:opportunities}, we have highlighted several possibilities.
+In Section \ref{sec:TODO}, we have highlighted several possibilities.
 
 Productive exchange between biology and evolutionary computation is a two-way street.
 Already, digital organisms find use cases in experiments conducted in conjunction with \textit{in vivo} inquiry \citep{sanjun2007selection,wilke2001evolution,hindr2012new}.

--- a/text/body/introduction.tex
+++ b/text/body/introduction.tex
@@ -74,16 +74,16 @@ With investment of effort, engaging theory from evolutionary biology can yield s
 Indeed, a good amount of existing research has already taken such an approach (Table \ref{tab:arbitrage-examples}).
 Our review highlights examples across three themes,
 \begin{itemize}
-  \item genotype-phenotype maps and fitness landscapes (Section \ref{sec:fitness-landscape});
-  \item ecological assembly and coexistence theory (Section \ref{sec:ecology}); and
-  \item phylogeny for prediction/analysis (Section \ref{sec:phylogeny-analysis}).
+  \item genotype-phenotype maps and fitness landscapes (Section \ref{sec:TODO});
+  \item ecological assembly and coexistence theory (Section \ref{sec:TODO}); and
+  \item phylogeny for prediction/analysis (Section \ref{sec:TODO}).
 \end{itemize}
 We also review practical work geared at overlapping evolutionary computation with bioinformatics infrastructure,
 \begin{itemize}
-  \item sampling-based approaches, which are friendly for decentralized infrastructure (Section \ref{sec:best-effort}); and
-  \item interoperation with bioinformatics infrastructure (Section \ref{sec:interoperation}).
+  \item sampling-based approaches, which are friendly for decentralized infrastructure (Section \ref{sec:TODO}); and
+  \item interoperation with bioinformatics infrastructure (Section \ref{sec:TODO}).
 \end{itemize}
-Additional opportunities for theory arbitrage remain entirely unexplored, however --- which we also outline (Section \ref{sec:opportunities}).
+Additional opportunities for theory arbitrage remain entirely unexplored, however --- which we also outline (Section \ref{sec:TODO}).
 
 \input{tab/arbitrage-examples.tex}
 


### PR DESCRIPTION
## Summary
This PR updates section references throughout the document to use `\ref{sec:TODO}` placeholders, indicating that these sections are still under development or need to be created. Additionally, the references file is uncommented in the main document.

## Key Changes
- **Introduction section**: Updated 5 cross-references to use `sec:TODO` placeholders:
  - `sec:fitness-landscape` → `sec:TODO`
  - `sec:ecology` → `sec:TODO`
  - `sec:phylogeny-analysis` → `sec:TODO`
  - `sec:best-effort` → `sec:TODO`
  - `sec:interoperation` → `sec:TODO`
  - `sec:opportunities` → `sec:TODO`

- **Conclusion section**: Updated 1 cross-reference:
  - `sec:opportunities` → `sec:TODO`

- **Main document**: Uncommented the references file input (`\input{text/references.tex}`)

## Notes
These changes appear to be part of a document restructuring or refactoring effort where section organization is being revised. The TODO placeholders suggest these sections will be properly defined and linked in a future update.

https://claude.ai/code/session_01Uh6DPoJF1W5rp8Nm3qTmwp