### PR TITLE
Fix malformed BibTeX entry in gabor2018preparing

### DIFF
--- a/bibl.bib
+++ b/bibl.bib
@@ -3142,7 +3142,6 @@
   pages = {131--140},
   doi = {10.1109/icac.2018.00023},
   url = {http://dx.doi.org/10.1109/ICAC.2018.00023},
-  fa
   booktitle = {2018 IEEE International Conference on Autonomic Computing ({ICAC})},
 }
 @article{gabor2021productive,


### PR DESCRIPTION
## Summary
Removed a stray incomplete line from the gabor2018preparing BibTeX entry that was causing a malformed bibliography entry.

## Key Changes
- Removed the incomplete line `fa` from the gabor2018preparing bibliography entry that appeared between the `url` field and `booktitle` field

## Details
The BibTeX entry contained a syntax error with an orphaned `fa` text on its own line, which would cause bibliography compilation issues. This line has been removed to restore the entry to a valid state.

https://claude.ai/code/session_012G4CZS9jH2vDUMevKK53xb